### PR TITLE
Add separate store for diary cookies

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -113,7 +113,7 @@ export class Client extends BaseClient {
         info,
         baseUrl,
         host: this.host,
-        createDiary: (): Promise<Diary> => Diary.create(baseUrl, this.host, info, this.cookieJar),
+        createDiary: (): Diary => new Diary(baseUrl, this.host, info, this.cookieJar),
       });
     }));
   }

--- a/src/diary/interfaces/user-object.ts
+++ b/src/diary/interfaces/user-object.ts
@@ -5,5 +5,5 @@ export interface UserObject {
   info: DiaryInfo;
   baseUrl: string;
   host: string;
-  createDiary: () => Promise<Diary>;
+  createDiary: () => Diary;
 }

--- a/tests/client.e2e.ts
+++ b/tests/client.e2e.ts
@@ -30,7 +30,7 @@ describe('Client', () => {
       await client.login('jan@fakelog.cf', 'jan123');
       const diaryList = await client.getDiaryList();
       expect(diaryList[0].host).toEqual('fakelog.cf');
-      await diaryList[0].createDiary();
+      diaryList[0].createDiary();
     });
   });
 

--- a/tests/diary.e2e.ts
+++ b/tests/diary.e2e.ts
@@ -13,7 +13,7 @@ describe('Diary', () => {
     client = new wulkanowy.Client('fakelog.cf');
     await client.login('jan@fakelog.cf', 'jan123');
     diaryList = await client.getDiaryList();
-    diary = await diaryList[0].createDiary();
+    diary = diaryList[0].createDiary();
   });
 
   afterAll(() => {


### PR DESCRIPTION
Without this change having multiple diary instances would lead to modifying the common cookie store when setting diary-specific cookies (`idBiezacyDziennik`, `idBiezacyUczen`, `biezacyRokSzkolny`, `idBiezacyDziennikPrzedszkole`).
I also realized that using async cookie store methods is unnecessary, as the default store is synchronous. This also allowed to remove the Diary.create method.